### PR TITLE
Update which to 7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ windows-console = []
 [dependencies]
 terminfo = "0.9.0"
 thiserror = "1.0.38"
-which = "6.0.1"
+which = "7.0.0"
 
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.28.0"


### PR DESCRIPTION
There shouldn’t be any source-code changes required here.

I’m not sure why dependabot didn’t propose this as it did in the past, e.g. https://github.com/watchexec/clearscreen/pull/19.